### PR TITLE
feat: add localstorage support, password history timestamps and glitch effect on password button

### DIFF
--- a/src/components/fredoist/CopyButton.svelte
+++ b/src/components/fredoist/CopyButton.svelte
@@ -11,11 +11,15 @@
 
 <button
 	type="button"
-	class="relative bg-[#f8ef00] text-black font-semibold uppercase py-5 px-10 border-r-2 border-[#ff003c] inline-flex items-center justify-between gap-x-16 [clip-path:polygon(100%_0,100%_25%,100%_100%,6%_100%,0%_70%,0_0)]"
+	class="group motion-reduce:animate-none relative bg-[#f8ef00] text-black font-semibold uppercase py-5 px-10 border-r-[3px] border-[#ff003c] inline-flex items-center justify-between gap-x-16 [clip-path:polygon(100%_0,100%_25%,100%_100%,6%_100%,0%_70%,0_0)]"
 	on:click={copyPassword}
 >
 	<span>Copy Password_</span>
-	<span class="absolute bg-black right-5 -bottom-px text-xs font-normal font-[Barlow,sans-serif] leading-none pl-2 pr-5 text-[#fafafa] border-l-2 border-[#ff003c]">R25</span>
+	<span class="fredoist-glitch-animation absolute inset-0 bg-[#f8ef00] hidden" />
+	<span
+		class="absolute bg-black right-5 -bottom-px text-xs font-normal font-[Barlow,sans-serif] leading-none pl-2 pr-5 text-[#fafafa] border-l-[3px] border-[#ff003c]"
+		>R25</span
+	>
 	<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 512 512">
 		<path
 			fill="none"
@@ -27,3 +31,123 @@
 		/>
 	</svg>
 </button>
+
+<style>
+	.group:hover .fredoist-glitch-animation {
+		display: block;
+		animation: fredoist-glitch-animation 2s linear infinite;
+	}
+
+	@keyframes fredoist-glitch-animation {
+		0% {
+			opacity: 1;
+			transform: translateZ(0);
+			clip-path: polygon(0 2%, 100% 2%, 100% 5%, 0 5%);
+		}
+
+		2% {
+			clip-path: polygon(0 78%, 100% 78%, 100% 100%, 0 100%);
+			transform: translate(-5px);
+		}
+
+		6% {
+			clip-path: polygon(0 78%, 100% 78%, 100% 100%, 0 100%);
+			transform: translate(5px);
+		}
+
+		8% {
+			clip-path: polygon(0 78%, 100% 78%, 100% 100%, 0 100%);
+			transform: translate(-5px);
+		}
+
+		9% {
+			clip-path: polygon(0 78%, 100% 78%, 100% 100%, 0 100%);
+			transform: translate(0);
+		}
+
+		10% {
+			clip-path: polygon(0 54%, 100% 54%, 100% 44%, 0 44%);
+			transform: translate3d(5px, 0, 0);
+		}
+
+		13% {
+			clip-path: polygon(0 54%, 100% 54%, 100% 44%, 0 44%);
+			transform: translateZ(0);
+		}
+
+		13.1% {
+			clip-path: polygon(0 0, 0 0, 0 0, 0 0);
+			transform: translate3d(5px, 0, 0);
+		}
+
+		15% {
+			clip-path: polygon(0 60%, 100% 60%, 100% 40%, 0 40%);
+			transform: translate3d(5px, 0, 0);
+		}
+
+		20% {
+			clip-path: polygon(0 60%, 100% 60%, 100% 40%, 0 40%);
+			transform: translate3d(-5px, 0, 0);
+		}
+
+		20.1% {
+			clip-path: polygon(0 0, 0 0, 0 0, 0 0);
+			transform: translate3d(5px, 0, 0);
+		}
+
+		25% {
+			clip-path: polygon(0 85%, 100% 85%, 100% 40%, 0 40%);
+			transform: translate3d(5px, 0, 0);
+		}
+
+		30% {
+			clip-path: polygon(0 85%, 100% 85%, 100% 40%, 0 40%);
+			transform: translate3d(-5px, 0, 0);
+		}
+
+		30.1% {
+			clip-path: polygon(0 0, 0 0, 0 0, 0 0);
+		}
+
+		35% {
+			clip-path: polygon(0 63%, 100% 63%, 100% 80%, 0 80%);
+			transform: translate(-5px);
+		}
+
+		40% {
+			clip-path: polygon(0 63%, 100% 63%, 100% 80%, 0 80%);
+			transform: translate(5px);
+		}
+
+		45% {
+			clip-path: polygon(0 63%, 100% 63%, 100% 80%, 0 80%);
+			transform: translate(-5px);
+		}
+
+		50% {
+			clip-path: polygon(0 63%, 100% 63%, 100% 80%, 0 80%);
+			transform: translate(0);
+		}
+
+		55% {
+			clip-path: polygon(0 10%, 100% 10%, 100% 0, 0 0);
+			transform: translate3d(5px, 0, 0);
+		}
+
+		60% {
+			clip-path: polygon(0 10%, 100% 10%, 100% 0, 0 0);
+			transform: translateZ(0);
+			opacity: 1;
+		}
+
+		60.1% {
+			clip-path: polygon(0 0, 0 0, 0 0, 0 0);
+			opacity: 1;
+		}
+
+		to {
+			clip-path: polygon(0 0, 0 0, 0 0, 0 0);
+			opacity: 1;
+		}
+	}
+</style>

--- a/src/components/fredoist/PasswordHistory.svelte
+++ b/src/components/fredoist/PasswordHistory.svelte
@@ -8,37 +8,54 @@
 	}
 </script>
 
-<div class="max-w-sm">
-	<h3 class="uppercase text-xl font-semibold tracking-widest cursor-default">Password History</h3>
-	<div class="fredoist-password-history relative my-8 flex flex-col gap-5 overflow-y-auto max-h-56">
-		{#each $history as password}
-			<div class="flex items-center justify-between gap-5">
-				<span class="truncate flex-1">{password}</span>
-				<button type="button" on:click={() => copyPassword(password)}>
-					<span class="sr-only">Copy password</span>
-					<svg
-						aria-hidden="true"
-						xmlns="http://www.w3.org/2000/svg"
-						class="w-6 h-6 fill-current"
-						viewBox="0 0 512 512"
-					>
-						<path
-							d="M456 480H136a24 24 0 01-24-24V128a16 16 0 0116-16h328a24 24 0 0124 24v320a24 24 0 01-24 24z"
-						/>
-						<path
-							d="M112 80h288V56a24 24 0 00-24-24H60a28 28 0 00-28 28v316a24 24 0 0024 24h24V112a32 32 0 0132-32z"
-						/>
-					</svg>
-				</button>
-			</div>
-		{/each}
+<div class="lg:max-w-sm">
+	<h3 class="uppercase text-xl font-semibold tracking-widest cursor-default">
+		Password History
+		<span class="text-xs font-normal font-[Barlow,sans-serif]">({$history.length})</span>
+	</h3>
+	<div
+		class="relative my-8 overflow-hidden after:absolute after:inset-x-0 after:bottom-0 after:h-12 after:bg-gradient-to-t after:from-black"
+	>
+		<div class="fredoist-password-history pb-12 flex flex-col gap-5 overflow-y-auto max-h-64">
+			{#each $history as password}
+				<div class="flex items-center justify-between gap-5">
+					<div class="flex-1 truncate">
+						<span class="block truncate">{password.value}</span>
+						<time
+							datetime={new Date(password.timestamp).toISOString()}
+							class="text-xs uppercase font-[Barlow,sans-serif] text-neutral-400"
+						>
+							{new Date(password.timestamp).toLocaleString()}
+						</time>
+					</div>
+					<button type="button" on:click={() => copyPassword(password.value)}>
+						<span class="sr-only">Copy password</span>
+						<svg
+							aria-hidden="true"
+							xmlns="http://www.w3.org/2000/svg"
+							class="w-6 h-6 fill-current"
+							viewBox="0 0 512 512"
+						>
+							<path
+								d="M456 480H136a24 24 0 01-24-24V128a16 16 0 0116-16h328a24 24 0 0124 24v320a24 24 0 01-24 24z"
+							/>
+							<path
+								d="M112 80h288V56a24 24 0 00-24-24H60a28 28 0 00-28 28v316a24 24 0 0024 24h24V112a32 32 0 0132-32z"
+							/>
+						</svg>
+					</button>
+				</div>
+			{/each}
+		</div>
 	</div>
 	{#if $history.length > 0}
 		<button
 			type="button"
 			class="w-full py-1 px-2 text-center text-[#f8ef00] tracking-widest"
-			on:click={history.clear}>Clear history</button
+			on:click={history.clear}
 		>
+			Clear history
+		</button>
 	{/if}
 </div>
 

--- a/src/components/fredoist/PasswordInput.svelte
+++ b/src/components/fredoist/PasswordInput.svelte
@@ -8,10 +8,6 @@
 	const options = useOptions()
 	const strength = useStrengthMeter()
 
-	onMount(() => {
-		password.generate()
-	})
-
 	$: $options && password.generate()
 
 	async function copyPassword(event: Event) {

--- a/src/components/fredoist/PasswordInput.svelte
+++ b/src/components/fredoist/PasswordInput.svelte
@@ -47,7 +47,7 @@
 		<svg
 			aria-hidden="true"
 			xmlns="http://www.w3.org/2000/svg"
-			class="w-6 h-6 fill-current"
+			class="w-6 h-6 fill-current hover:-rotate-12 transition-transform duration-200"
 			viewBox="0 0 512 512"
 		>
 			<path

--- a/src/hooks/fredoist/use-history.ts
+++ b/src/hooks/fredoist/use-history.ts
@@ -1,13 +1,17 @@
 import { writable } from 'svelte/store'
 import { usePassword } from '@hooks/fredoist/use-password'
 
-const history = writable<string[]>(JSON.parse(localStorage.getItem('fredoist_history')) || [])
+const history = writable<{ value: string; timestamp: number }[]>(
+	JSON.parse(localStorage.getItem('fredoist_history')) || []
+)
 
 export function useHistory() {
 	const { subscribe, set, update } = history
 	const password = usePassword()
 	password.subscribe((password) =>
-		update((items) => (password !== '' && !items.includes(password) ? [password, ...items] : items))
+		update((items) =>
+			password !== '' ? [{ value: password, timestamp: Date.now() }, ...items] : items
+		)
 	)
 
 	const clear = () => {

--- a/src/hooks/fredoist/use-history.ts
+++ b/src/hooks/fredoist/use-history.ts
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store'
 import { usePassword } from '@hooks/fredoist/use-password'
 
-const history = writable<string[]>([])
+const history = writable<string[]>(JSON.parse(localStorage.getItem('fredoist_history')) || [])
 
 export function useHistory() {
 	const { subscribe, set, update } = history
@@ -13,6 +13,8 @@ export function useHistory() {
 	const clear = () => {
 		set([])
 	}
+
+	subscribe((items) => localStorage.setItem('fredoist_history', JSON.stringify(items)))
 
 	return {
 		subscribe,

--- a/src/hooks/fredoist/use-options.ts
+++ b/src/hooks/fredoist/use-options.ts
@@ -8,13 +8,15 @@ const DEFAULT_OPTIONS = {
 	symbols: true
 }
 
-const options = writable(DEFAULT_OPTIONS)
+const options = writable(JSON.parse(localStorage.getItem('fredoist_options')) || DEFAULT_OPTIONS)
 
 export const useOptions = () => {
 	const { subscribe, update: updateStore } = options
 
 	const update = (values: Partial<typeof DEFAULT_OPTIONS>) =>
 		updateStore((current) => ({ ...current, ...values }))
+
+	subscribe((values) => localStorage.setItem('fredoist_options', JSON.stringify(values)))
 
 	return {
 		subscribe,

--- a/src/hooks/fredoist/use-strengthmeter.ts
+++ b/src/hooks/fredoist/use-strengthmeter.ts
@@ -3,7 +3,7 @@ import { usePassword } from '@hooks/fredoist/use-password'
 
 const DEFAULT_VALUES = {
 	score: 0,
-	description: 'Bad'
+	description: 'Empty'
 }
 
 const StrongPassword = /(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9])(?=.{16,})/


### PR DESCRIPTION
# ⭐ Descripción

Now passwords and options are saved on localstorage to preserve on page reloads, also added local timestamp for a generated password so it's easier to identify, added glitch effect on copy button. Also, fixed some re-render issues.

## 🚀 Tipo de cambio

- [x] Arreglo de bug (cambios que no rompen nada y resuelven un problema).
- [x] Nueva característica (cambios que no rompen nada y agregan funcionalidad).
- [ ] Cambio radical (arreglo o característica que podría causar que una funcionalidad no funcione como se espera).
- [ ] Este cambio requiere actualización de documentación.

**Configuración de pruebas**:
- Versión de Node: 18.10.0
- Versión de Astro: 1.3.1

# 📝 Lista de verificación:
(*) -> obligatorio.

- [x] Mi código sigue [las reglas](https://github.com/midudev/password-generator#-reglas) de este proyecto *.
- [x] He creado mis propias clases / ids y he comprobado que no afectan a otros diseños de la comunidad *.
- [x] He realizado una auto-revisión de mi propio código *.
- [x] He comentado mi código, particularmente en las áreas difíciles de entender.
- [x] Mis cambios no generan nuevos avisos *.
- [x] No he instalado nuevos módulos con `npm install` o `yarn install` *.
- [x] La solución es de mi autoría y no he copiado código de otros participantes *.
- [x] No modifiqué ningún otro archivo más que los míos *.
